### PR TITLE
Add configurable links in Navigation

### DIFF
--- a/src/devlink/Navigation.d.ts
+++ b/src/devlink/Navigation.d.ts
@@ -1,5 +1,17 @@
 import * as React from "react";
 
-declare function Navigation(props: {
+export interface NavigationProps {
   as?: React.ElementType;
-}): React.JSX.Element;
+  /** Text for the "Features" nav item */
+  navbarLinkFeatures?: React.ReactNode;
+  /** Text for the "Products" nav item */
+  navbarLinkProducts?: React.ReactNode;
+  /** Text for the "Resources" nav item */
+  navbarLinkResources?: React.ReactNode;
+  /** Text for the "Contact" nav item */
+  navbarLinkContact?: React.ReactNode;
+}
+
+declare function Navigation(props: NavigationProps): React.JSX.Element;
+
+export { Navigation, NavigationProps };

--- a/src/devlink/Navigation.js
+++ b/src/devlink/Navigation.js
@@ -4,7 +4,13 @@ import * as _Builtin from "./_Builtin";
 import * as _utils from "./utils";
 import _styles from "./Navigation.module.css";
 
-export function Navigation({ as: _Component = _Builtin.Block }) {
+export function Navigation({
+  as: _Component = _Builtin.Block,
+  navbarLinkFeatures = "Features",
+  navbarLinkProducts = "Products",
+  navbarLinkResources = "Resources",
+  navbarLinkContact = "Contact",
+}) {
   return (
     <_Component className={_utils.cx(_styles, "nav", "inverse-nav")} tag="div">
       <_Builtin.NavbarWrapper
@@ -117,7 +123,7 @@ export function Navigation({ as: _Component = _Builtin.Block }) {
                     )}
                     tag="div"
                   >
-                    <_Builtin.Block tag="div">{"Features"}</_Builtin.Block>
+                    <_Builtin.Block tag="div">{navbarLinkFeatures}</_Builtin.Block>
                     <_Builtin.Icon
                       className={_utils.cx(_styles, "nav-caret")}
                       widget={{
@@ -1114,7 +1120,7 @@ export function Navigation({ as: _Component = _Builtin.Block }) {
                               className={_utils.cx(_styles, "button-label")}
                               tag="div"
                             >
-                              {"Contact"}
+                              {navbarLinkContact}
                             </_Builtin.Block>
                           </_Builtin.Link>
                         </_Builtin.ListItem>


### PR DESCRIPTION
## Summary
- allow customizing Navigation labels via props

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f74367948325be92b5a8c405494a