### PR TITLE
Fix FormWrapper children handling

### DIFF
--- a/src/devlink/_Builtin/Form.js
+++ b/src/devlink/_Builtin/Form.js
@@ -15,8 +15,9 @@ export const FormWrapper = React.forwardRef(function FormWrapper(
   ref
 ) {
   const [state, setState] = React.useState(initialState);
+  const childArray = React.Children.toArray(children);
   const formName =
-    (children.find((c) => c.type === FormForm)?.props)["data-name"] ?? "Form";
+    (childArray.find((c) => c.type === FormForm)?.props)["data-name"] ?? "Form";
   return React.createElement(
     "div",
     {


### PR DESCRIPTION
## Summary
- fix FormWrapper to handle single child correctly

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866057a233083258764ccecfca5712b